### PR TITLE
Drop CUDA 11.2 and 11.5, add Python 3.11 and 3.12.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CUDA_VER=11.8.0
+ARG CUDA_VER=12.0.1
 ARG LINUX_VER=ubuntu22.04
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
 

--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -1,7 +1,6 @@
 def compute_arch($x):
   ["amd64"] |
   if
-    $x.CUDA_VER > "11.2.2" and
     $x.LINUX_VER != "centos7"
   then
     . + ["arm64"]

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -1,13 +1,13 @@
 CUDA_VER:
-  - "11.2.2"
   - "11.4.3"
-  - "11.5.2"
   - "11.8.0"
   - "12.0.1"
   - "12.1.1"
 PYTHON_VER:
   - "3.9"
   - "3.10"
+  - "3.11"
+  - "3.12"
 LINUX_VER:
   - "ubuntu20.04"
   - "ubuntu22.04"
@@ -17,8 +17,4 @@ IMAGE_REPO:
   - "miniforge-cuda"
 exclude:
   - LINUX_VER: "ubuntu22.04"
-    CUDA_VER: "11.2.2"
-  - LINUX_VER: "ubuntu22.04"
     CUDA_VER: "11.4.3"
-  - LINUX_VER: "ubuntu22.04"
-    CUDA_VER: "11.5.2"


### PR DESCRIPTION
Since CUDA 11.2 and 11.5 have been dropped from our shared testing workflows, we no longer need images for CUDA 11.2 and 11.5. At the same time, we will need images for newer Python versions in order to support pynvjitlink which we expect to be consumed outside of RAPIDS (which currently supports Python 3.9 and 3.10). It would also be helpful to have newer Python images so that we can expand RAPIDS support.