### PR TITLE
Downgrade `conda`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ umask 002
 # install expected Python version
 mamba install -y -n base python="${PYTHON_VERSION}"
 mamba update --all -y -n base
+# TODO: remove pin after `conda env create --force` usage is removed across
+# RAPIDS
+mamba install -y "conda<24.3"
 if [[ "$LINUX_VER" == "rockylinux"* ]]; then
   yum install -y findutils
   yum clean all


### PR DESCRIPTION
This PR temporarily downgrades conda to a version prior to `24.3.0`.

This is necessary because `24.3.0` removed support for `conda env create --force`, which we use.

See the links below for more details:

- https://github.com/conda/conda/blob/main/CHANGELOG.md#2430-2024-03-12
- https://github.com/conda/conda/pull/13634