### PR TITLE
Switch to Conda to install & update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN <<EOF
 # Ensure new files/dirs have group write permissions
 umask 002
 # install expected Python version
-mamba install -y -n base python="${PYTHON_VERSION}"
-mamba update --all -y -n base
+conda install -y -n base python="${PYTHON_VERSION}"
+conda update --all -y -n base
 if [[ "$LINUX_VER" == "rockylinux"* ]]; then
   yum install -y findutils
   yum clean all


### PR DESCRIPTION
As [Conda uses the `libmamba` solver by default]( https://conda.org/blog/2023-11-06-conda-23-10-0-release ), switch to using Conda to install and upgrade packages.

This also fixes an issue that Mamba runs into with Python 3.9 builds that Conda does not have issues with. Here is [an example]( https://github.com/rapidsai/miniforge-cuda/actions/runs/8725776237/job/23939585460 )