### PR TITLE
Drop CentOS 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ case "${LINUX_VER}" in
       tzdata
     rm -rf "/var/lib/apt/lists/*"
     ;;
-  "centos"* | "rockylinux"*)
+  "rockylinux"*)
     yum update -y
     yum clean all
     ;;

--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -1,12 +1,5 @@
 def compute_arch($x):
-  ["amd64"] |
-  if
-    $x.LINUX_VER != "centos7"
-  then
-    . + ["arm64"]
-  else
-    .
-  end |
+  ["amd64", "arm64"] |
   $x + {ARCHES: .};
 
 # Checks the current entry to see if it matches the given exclude

--- a/ci/compute-matrix.jq
+++ b/ci/compute-matrix.jq
@@ -1,6 +1,5 @@
 def compute_arch($x):
-  ["amd64", "arm64"] |
-  $x + {ARCHES: .};
+  $x + {ARCHES: ["amd64", "arm64"]};
 
 # Checks the current entry to see if it matches the given exclude
 def matches($entry; $exclude):

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -11,7 +11,6 @@ PYTHON_VER:
 LINUX_VER:
   - "ubuntu20.04"
   - "ubuntu22.04"
-  - "centos7"
   - "rockylinux8"
 IMAGE_REPO:
   - "miniforge-cuda"


### PR DESCRIPTION
This PR drops CentOS 7 from the miniforge-cuda matrix.
