### PR TITLE
Update README to point to ci-imgs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > [!IMPORTANT]
 > `miniforge-cuda` images are now generated in https://github.com/rapidsai/ci-imgs. Please direct issues and pull requests to that repository.
+>
+> See https://github.com/rapidsai/build-planning/issues/48 for more information.
 
 A simple set of images that install [Miniforge](https://github.com/conda-forge/miniforge) on top of the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) images.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # miniforge-cuda
 
+> [!IMPORTANT]
+> `miniforge-cuda` images are now generated in https://github.com/rapidsai/ci-imgs. Please direct issues and pull requests to that repository.
+
 A simple set of images that install [Miniforge](https://github.com/conda-forge/miniforge) on top of the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) images.
 
 These images are intended to be used as a base image for other RAPIDS images. Downstream images can create a user with the `conda` user group which has write access to the base conda environment in the image.


### PR DESCRIPTION
Update README to point to `ci-imgs`.

Contributes to https://github.com/rapidsai/build-planning/issues/48.
